### PR TITLE
s/consumer/producer in stream cancellation description

### DIFF
--- a/presentation/README.md
+++ b/presentation/README.md
@@ -491,7 +491,7 @@ open the door for triangulating async generator functions.
 
 Another dimension of concern for asynchronous singular values is whether
 information only flows from producer to consumer, or whether some information
-can propagate back to the consumer like cancellation.
+can propagate back to the producer like cancellation.
 For something like cancellation to work, information has to flow back up stream.
 That information could then propagate downstream to any other consumers.
 This would constitute another form of plan interference.


### PR DESCRIPTION
In a cancellation situation, I believe the information would flow up stream to the _producer_ as opposed to the consumer, so a possible typo?